### PR TITLE
add 'on banlist' attr

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "ethers": "^5.6.8",
     "next": "12.1.6",
     "react": "18.1.0",
-    "react-dom": "18.1.0"
+    "react-dom": "18.1.0",
+    "swearjar": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "17.0.38",

--- a/pages/api/tokenData/static.ts
+++ b/pages/api/tokenData/static.ts
@@ -5,8 +5,9 @@ import {
   hex2bin,
   getHashesContract
 } from '../../../util';
+import * as swearjar from 'swearjar';
 
-type BinaryAttribute = { trait_type: string, value: number };
+type BinaryAttribute = { trait_type: string, value: number | boolean | string };
 
 type ResponseData = {
   hash: string
@@ -60,6 +61,10 @@ function getPhraseAttributes(
     {
       trait_type: 'character amount',
       value: phraseCharCount
+    },
+    {
+      trait_type: 'on banlist',
+      value: swearjar.profane(phrase) ? true : false
     }
   ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,6 +2058,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swearjar@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/swearjar/-/swearjar-0.2.0.tgz#c3f1a37bfcd7c9efb3d6663c98d4c102a9e3ca3d"
+  integrity sha1-w/Gje/zXye+z1mY8mNTBAqnjyj0=
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
This PR adds the [swearjar](https://github.com/raymondjavaxx/swearjar-node) npm package and an associated 'on banlist' attribute for seed phrases. If a word is on the banlist, the seed phrase is not allowed to be shown on any associated minted NFTs.